### PR TITLE
[#18] Expand the dir path to also accept files

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,7 +3,7 @@ use structopt::StructOpt;
 
 #[derive(StructOpt)]
 pub struct CLI {
-    // Flag to search all classes with that value
+    /// Flag to search all classes with that value
     #[structopt(
         short = "g",
         long = "grep",
@@ -11,11 +11,11 @@ pub struct CLI {
     )]
     pub grep: bool,
 
-    // Class name to be fetched
+    /// Class name to be fetched
     #[structopt(help = "Name of the Python class")]
     pub class_name: String,
 
-    // Search directory
+    /// Search path
     #[structopt(parse(from_os_str), default_value = ".", help = "Search directory")]
-    pub dir_path: PathBuf,
+    pub path: PathBuf,
 }

--- a/src/joneslib/loader.rs
+++ b/src/joneslib/loader.rs
@@ -38,7 +38,6 @@ pub fn load_python_project(path: &PathBuf) -> Option<Vec<(String, String)>> {
         }
     };
 
-
     let file_pattern_captures = file_name_pattern.captures_iter(&script_output);
     let found_classes = class_name_pattern
         .captures_iter(&script_output)

--- a/src/joneslib/mod.rs
+++ b/src/joneslib/mod.rs
@@ -85,8 +85,8 @@ pub fn project_traversal(dir_path: &PathBuf, class_name: &String) -> Option<obje
 
 /// Loads the project classes and filters them by the class name. Returns a vector
 /// of tuples containing the class name and the file path.
-pub fn search(dir_path: &PathBuf, class_name: &String) -> Option<Vec<ClassMatch>> {
-    let project_classes = match loader::load_python_project(dir_path) {
+pub fn search(path: &PathBuf, class_name: &String) -> Option<Vec<ClassMatch>> {
+    let project_classes = match loader::load_python_project(path) {
         Some(classes) => classes,
         None => {
             println!("Error occurred while loading project classes");

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,13 +18,13 @@ fn main() {
     let comms = commands::CLI::from_args();
     if comms.grep {
         // Search for a keyword in class name
-        match joneslib::search(&comms.dir_path, &comms.class_name) {
+        match joneslib::search(&comms.path, &comms.class_name) {
             Some(matches) => display::class_matches(matches),
             None => display::not_found_message(),
         }
     } else {
         // Generate python class
-        match joneslib::project_traversal(&comms.dir_path, &comms.class_name) {
+        match joneslib::project_traversal(&comms.path, &comms.class_name) {
             Some(class) => joneslib::display::output_class(&class),
             None => display::not_found_message(),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
         }
     } else {
         // Generate python class
-        match joneslib::project_traversal(&comms.path, &comms.class_name) {
+        match joneslib::fetch_object_details(&comms.path, &comms.class_name) {
             Some(class) => joneslib::display::output_class(&class),
             None => display::not_found_message(),
         }


### PR DESCRIPTION
Extended the search & fetch capabilities to also accept file paths. This way if a file path is given the class can be searched only there.

Related to issue #18 